### PR TITLE
Adding restify to supported instrumentations

### DIFF
--- a/_data/existing_instrumentations.yml
+++ b/_data/existing_instrumentations.yml
@@ -2,7 +2,7 @@
   library: >-
     [zipkin-js](https://github.com/openzipkin/zipkin-js)
   framework: >-
-    [cujoJS](http://cujojs.com), [express](http://expressjs.com/)
+    [cujoJS](http://cujojs.com), [express](http://expressjs.com/), [restify](http://restify.com/)
   propagation: Http (B3)
   transports: >-
     [Kafka \\| Scribe](https://github.com/openzipkin/zipkin-js#transports)


### PR DESCRIPTION
As a result of [this PR](https://github.com/openzipkin/zipkin-js/pull/20), adding [restify](http://restify.com/) as a supported framework.