### PR TITLE
adding HTTP to supported JS transports

### DIFF
--- a/_data/existing_instrumentations.yml
+++ b/_data/existing_instrumentations.yml
@@ -5,7 +5,7 @@
     [cujoJS](http://cujojs.com), [express](http://expressjs.com/), [restify](http://restify.com/)
   propagation: Http (B3)
   transports: >-
-    [Kafka \\| Scribe](https://github.com/openzipkin/zipkin-js#transports)
+    [Http \\| Kafka \\| Scribe](https://github.com/openzipkin/zipkin-js#transports)
   sampling: >-
     Yes
   notes: >-


### PR DESCRIPTION
Adding [Http](https://github.com/openzipkin/zipkin-js/pull/23) to the list of available transports for zipkin-js.