### PR TITLE
list zipkin-go-opentracing as stand-alone option

### DIFF
--- a/_data/existing_instrumentations.yml
+++ b/_data/existing_instrumentations.yml
@@ -98,8 +98,8 @@
 
 - language: Go
   library: >-
-    [Go kit](https://github.com/go-kit/kit)
-  framework: Go kit
+    [zipkin-go-opentracing](https://github.com/openzipkin/zipkin-go-opentracing)
+  framework: [Go kit](https://gokit.io) or roll your own with [OpenTracing](http://opentracing.io)
   propagation: Http (B3), gRPC (B3)
   transports: Kafka, Scribe
   sampling: "Yes"


### PR DESCRIPTION
Even though `zipkin-go-opentracing` in combination with `Go kit` is a really good option (I highly recommend going this route) the tracing library itself is fully `OpenTracing API` compatible and can easily be used in other frameworks or roll your own environments. closes #42 