### PR TITLE
fix yml error in existing instrumentations data file

### DIFF
--- a/_data/existing_instrumentations.yml
+++ b/_data/existing_instrumentations.yml
@@ -99,7 +99,8 @@
 - language: Go
   library: >-
     [zipkin-go-opentracing](https://github.com/openzipkin/zipkin-go-opentracing)
-  framework: [Go kit](https://gokit.io) or roll your own with [OpenTracing](http://opentracing.io)
+  framework: >-
+    [Go kit](https://gokit.io) or roll your own with [OpenTracing](http://opentracing.io)
   propagation: Http (B3), gRPC (B3)
   transports: Kafka, Scribe
   sampling: "Yes"


### PR DESCRIPTION
This fixes the yaml syntax error I introduced when updating the zipkin-go-opentracing listing.