### PR TITLE
Fixes bullet list of Zipkin components

### DIFF
--- a/pages/architecture.md
+++ b/pages/architecture.md
@@ -27,6 +27,7 @@ Spans sent by the instrumented library must be transported from the services bei
 There are two primary transports: Scribe and Kafka. Scribe is shown in the figure. See [Span Receivers]({{ site.github.url }}/pages/span_receivers) for more information.
 
 There are 4 components that make up Zipkin:
+
 * collector
 * storage
 * search


### PR DESCRIPTION
As it isn't rendered correctly on the website.

<details>

![image](https://cloud.githubusercontent.com/assets/719616/19071982/19067886-8a33-11e6-94bd-b0a14a22871b.png)
</details>
