### PR TITLE
Adds simplest example of set Span.timestamp and duration

### DIFF
--- a/pages/instrumenting.md
+++ b/pages/instrumenting.md
@@ -225,6 +225,14 @@ microseconds.
 
 Span.timestamp and duration should only be set by the host that started the span.
 
+The simplest logic is generally this:
+
+```
+unless (logging "sr" in an existing span) {
+ set Span.timestamp and duration
+}
+```
+
 Zipkin merges spans together that share the same trace and span ID. The most
 common case of this is to merge a span reported by both the client (cs, cr) and
 the server (sr, ss). For example, the client starts a span, logging "cs" and


### PR DESCRIPTION
I made some insights when collaborating with @paolochiodi. This change represents the simplest pseudocode I can think of for how to understand when you should set Span.timestamp and duration. 

https://github.com/paolochiodi/zipkin-simple/pull/2#issuecomment-250770128

cc @basvanbeek 