### PR TITLE
add php  instrumentation "Molten"

### DIFF
--- a/_data/community_instrumentations.yml
+++ b/_data/community_instrumentations.yml
@@ -177,3 +177,12 @@
   transports: "http, log file"
   sampling: "Yes"
   notes: Simple and full implementation without dependencies. Very flexible.
+  
+  - language: PHP
+  library: >-
+    [Molten](https://github.com/chuan-yun/Molten)
+  framework: Any
+  propagation: "B3"
+  transports: "http, log file, syslog"
+  sampling: "Yes"
+  notes: Application transparent;php5.6 or higher;auto trace pdo/mysqli/curl/memcached/redis;auto add http B3 header.


### PR DESCRIPTION
 Molten is application transparent php extension, user do not change anything, just install the molten extension, so they can see in zipkin server. 
please see https://github.com/chuan-yun/Molten#quickstart, you can see tracing info in zipkin server.