### PR TITLE
Extend quickstart.sh to download any artifact

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -177,7 +177,7 @@ main() {
 
     echo "Downloading $artifact_group:$artifact_id:$latest_version:$artifact_classifier to $filename..."
     local url="https://dl.bintray.com/openzipkin/maven/${artifact_group//./\/}/${artifact_id}/$latest_version/${artifact_id}-${latest_version}${artifact_classifier_suffix}.jar"
-    curl -sL -o "$filename" "$url"
+    curl -L -o "$filename" "$url"
     verify_checksum "$url" "$filename"
     verify_signature "$url" "$filename"
     verify_signature "$url.md5" "$filename.md5"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -61,7 +61,7 @@ with the debug flag like below, and open an issue on
 https://github.com/openzipkin/zipkin/issues/new. Make sure to include the
 full output of the run.
 
-    \curl -sSL http://zipkin.io/quickstart.sh | bash -sx $@
+    \curl -sSL http://zipkin.io/quickstart.sh | bash -sx -- $@
 
 In the meanwhile, you can manually download and run the latest executable jar
 from the following URL:

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -177,6 +177,7 @@ main() {
 
     echo "Downloading $artifact_group:$artifact_id:$latest_version:$artifact_classifier to $filename..."
     local url="https://dl.bintray.com/openzipkin/maven/${artifact_group//./\/}/${artifact_id}/$latest_version/${artifact_id}-${latest_version}${artifact_classifier_suffix}.jar"
+    echo "$url -> $filename"
     curl -L -o "$filename" "$url"
     verify_checksum "$url" "$filename"
     verify_signature "$url" "$filename"


### PR DESCRIPTION
As discussed in #93. Example session:

```console
$ ./quickstart.sh -h
./quickstart.sh
Downloads the latest version of the Zipkin Server executable jar

./quickstart.sh GROUP:ARTIFACT:CLASSIFIER TARGET
Downloads the latest version of GROUP:ARTIFACT with classifier "CLASSIFIER"
to path "TARGET" on the local file system. For example:

./quickstart.sh io.zipkin.java:zipkin-autoconfigure-collector-kafka10:module kafka10.jar
downloads the latest version of the artifact with group "io.zipkin.java",
artifact id "zipkin-autoconfigure-collector-kafka10", and classifier "module"
to PWD/kafka10.jar
$ ./quickstart.sh
Thank you for trying OpenZipkin!

This installer is provided as a quick-start helper, so you can try Zipkin out
without a lengthy installation process.

Fetching version number of latest Zipkin release...
Downloading io.zipkin.java:zipkin-server:2.4.0:exec to zipkin.jar...
https://dl.bintray.com/openzipkin/maven/io/zipkin/java/zipkin-server/2.4.0/zipkin-server-2.4.0-exec.jar -> zipkin.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 48.9M  100 48.9M    0     0  2786k      0  0:00:18  0:00:18 --:--:-- 3012k

Verifying checksum...
zipkin.jar: OK

Verifying signature of zipkin.jar...
gpg: Signature made Mon 27 Nov 2017 11:52:09 AM CET
gpg:                using RSA key 379CE192D401AB61
gpg: Good signature from "Bintray (by JFrog) <bintray@bintray.com>" [ultimate]

Verifying signature of zipkin.jar.md5...
gpg: Signature made Mon 27 Nov 2017 11:52:10 AM CET
gpg:                using RSA key 379CE192D401AB61
gpg: Good signature from "Bintray (by JFrog) <bintray@bintray.com>" [ultimate]

You can now run the downloaded executable jar:

    java -jar zipkin.jar

$ ls -lh zipkin.jar
-rw-rw-r-- 1 abesto abesto 49M Nov 27 21:30 zipkin.jar
$ ./quickstart.sh io.zipkin.java:zipkin-autoconfigure-collector-kafka10:module kafka10.jar
Thank you for trying OpenZipkin!

This installer is provided as a quick-start helper, so you can try Zipkin out
without a lengthy installation process.

Fetching version number of latest Zipkin release...
Downloading io.zipkin.java:zipkin-autoconfigure-collector-kafka10:2.4.0:module to kafka10.jar...
https://dl.bintray.com/openzipkin/maven/io/zipkin/java/zipkin-autoconfigure-collector-kafka10/2.4.0/zipkin-autoconfigure-collector-kafka10-2.4.0-module.jar -> kafka10.jar
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 2667k  100 2667k    0     0  2667k      0  0:00:01  0:00:01 --:--:-- 3124k

Verifying checksum...
kafka10.jar: OK

Verifying signature of kafka10.jar...
gpg: Signature made Mon 27 Nov 2017 11:52:40 AM CET
gpg:                using RSA key 379CE192D401AB61
gpg: Good signature from "Bintray (by JFrog) <bintray@bintray.com>" [ultimate]

Verifying signature of kafka10.jar.md5...
gpg: Signature made Mon 27 Nov 2017 11:52:41 AM CET
gpg:                using RSA key 379CE192D401AB61
gpg: Good signature from "Bintray (by JFrog) <bintray@bintray.com>" [ultimate]

The downloaded artifact is now available at kafka10.jar.
$ ls -lh kafka10.jar
-rw-rw-r-- 1 abesto abesto 2.7M Nov 27 21:31 kafka10.jar