### PR TITLE
Adds zipkin-go to list of official libraries

### DIFF
--- a/_data/openzipkin_instrumentations.yml
+++ b/_data/openzipkin_instrumentations.yml
@@ -10,6 +10,16 @@
 
 - language: Go
   library: >-
+    [zipkin-go](https://github.com/openzipkin/zipkin-go)
+  framework: >-
+    standard Go middlewares
+  propagation: Http (B3), gRPC (B3)
+  transports: Http (v2), Kafka (v2), Log
+  sampling: "Yes"
+  notes: Uses Zipkin V2 API
+
+- language: Go
+  library: >-
     [zipkin-go-opentracing](https://github.com/openzipkin/zipkin-go-opentracing)
   framework: >-
     [Go kit](https://gokit.io), or roll your own with [OpenTracing](http://opentracing.io)


### PR DESCRIPTION
zipkin-go is ready for usage now. add to list of officially supported tracers