### PR TITLE
Document using quickstart script

### DIFF
--- a/pages/quickstart.md
+++ b/pages/quickstart.md
@@ -26,7 +26,7 @@ docker run -d -p 9411:9411 openzipkin/zipkin
 If you have Java 8 or higher installed, the quickest way to get started is to fetch the [latest release](https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec) as a self-contained executable jar:
 
 ~~~ bash
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 java -jar zipkin.jar
 ~~~
 


### PR DESCRIPTION
While the READMEs had been updated to mention using the bash script, the website was still instructing to use `wget`. This syncs the website's instructions with the READMEs.