### PR TITLE
move zipkin-go-opentracing to community contrib

### DIFF
--- a/_data/community_instrumentations.yml
+++ b/_data/community_instrumentations.yml
@@ -31,6 +31,16 @@
 
 - language: Go
   library: >-
+    [zipkin-go-opentracing](https://github.com/openzipkin/zipkin-go-opentracing)
+  framework: >-
+    [Go kit](https://gokit.io), or roll your own with [OpenTracing](http://opentracing.io)
+  propagation: Http (B3), gRPC (B3)
+  transports: Http, Kafka, Scribe
+  sampling: "Yes"
+  notes:
+
+- language: Go
+  library: >-
     [go-zipkin](https://github.com/elodina/go-zipkin)
   framework: x/net Context
   propagation:
@@ -178,7 +188,7 @@
   sampling: >-
     [Yes](https://github.com/aio-libs/aiozipkin/blob/a1a239d6f5a42fce35ecc9810c09eb4ac1d89780/aiozipkin/tracer.py#L9-L10)
   notes: Supported python 3.5+ and native coroutines.
-  
+
 - language: Scala
   library: >-
     [akka-tracing](https://github.com/levkhomich/akka-tracing)
@@ -203,7 +213,7 @@
   library: >-
     [sttp](https://github.com/softwaremill/sttp)
   framework: >-
-    [akka-http](https://doc.akka.io/docs/akka-http/current/index.html), 
+    [akka-http](https://doc.akka.io/docs/akka-http/current/index.html),
     [async-http-client](https://github.com/AsyncHttpClient/async-http-client)
   propagation: Http (B3)
   transports: Http

--- a/_data/openzipkin_instrumentations.yml
+++ b/_data/openzipkin_instrumentations.yml
@@ -18,16 +18,6 @@
   sampling: "Yes"
   notes: Uses Zipkin V2 API
 
-- language: Go
-  library: >-
-    [zipkin-go-opentracing](https://github.com/openzipkin/zipkin-go-opentracing)
-  framework: >-
-    [Go kit](https://gokit.io), or roll your own with [OpenTracing](http://opentracing.io)
-  propagation: Http (B3), gRPC (B3)
-  transports: Http, Kafka, Scribe
-  sampling: "Yes"
-  notes:
-
 - language: Java
   library: >-
     [brave](https://github.com/openzipkin/brave)
@@ -69,7 +59,7 @@
   transports: Http, Kafka, Scribe
   sampling: "Yes"
   notes: Library is written in Java. Propagation is defined in Finagle itself.
-  
+
 - language: PHP
   library: >-
     [zipkin-php](https://github.com/openzipkin/zipkin-php)
@@ -78,4 +68,3 @@
   transports: "http, log file"
   sampling: "Yes"
   notes: V2 native based on brave's model, compatible with PHP 5.6 and PHP 7.x. Check [this](https://github.com/openzipkin/zipkin-php-example) out for an example.
-


### PR DESCRIPTION
Demoting zipkin-go-opentracing to community contrib support level as we have much better idiomatic Zipkin instrumentation for Go through the zipkin-go project.

