### PR TITLE
Fix #112: quickstart is grabbing the wrong version for external modules

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -82,7 +82,7 @@ EOF
 fetch_latest_version() {
     local artifact_group="$1"; shift
     local artifact_id="$1"; shift
-    local url="https://api.bintray.com/search/packages/maven?g=${artifact_group}&a=${artifact_id}"
+    local url="https://api.bintray.com/search/packages/maven?g=${artifact_group}&a=${artifact_id}&subject=openzipkin"
     local package_data="$(curl -fsL "$url")"
     local package_count
     local have_jq


### PR DESCRIPTION
Had to change the API used here, since originally the script had no way of knowing which Bintray repo the artifact is published into. For example, the Maven artifact `io.zipkin.aws:zipkin-autoconfigure-collector-kinesis` lives in the `zipkin-aws` Bintray repo. The `/search/packages/maven` API does what we need, but can potentially return multiple matches (if the same artifact lives in multiple repositories). The added complexity is to protect against this case.