### PR TITLE
Quickstart/improvements

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -44,7 +44,7 @@ farewell() {
     local artifact_classifier="$1"; shift
     local filename="$1"; shift
     echo -n "$color_good"
-    if [ "$artifact_classifier" = 'exec' ]; then
+    if [[ "$artifact_classifier" = 'exec' ]]; then
         cat <<EOF
 
 You can now run the downloaded executable jar:
@@ -63,7 +63,7 @@ EOF
 
 cleanup() {
     local base_filename="$1"; shift
-    if [ "$DO_CLEANUP" -eq 0 ]; then
+    if [[ "$DO_CLEANUP" -eq 0 ]]; then
         echo
         echo "${color_title}Cleaning up checksum and signature files${color_reset}"
         execute_and_log rm -f "$base_filename"{.md5,.asc,.md5.asc}
@@ -74,7 +74,7 @@ cleanup() {
 handle_shutdown() {
     local status=$?
     local base_filename="$1"; shift
-    if [ $status -eq 0 ]; then
+    if [[ $status -eq 0 ]]; then
         cleanup "$base_filename"
     else
         cat <<EOF
@@ -155,7 +155,7 @@ artifact_part() {
 }
 
 verify_version_number() {
-    if ! echo "$1" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' >/dev/null 2>&1; then
+    if [[ ! "$1" =~ ^[[:digit:]+\.[[:digit:]]+\.[[:digit:]]+$ ]]; then
         cat <<EOF
 ${color_bad}The target version is "$1". That doesn't look like a valid Zipkin release version
 number; this script is confused. Bailing out.
@@ -227,14 +227,14 @@ main() {
     local artifact_group_with_slashes
     local artifact_url
 
-    if [ $# -eq 0 ]; then
+    if [[ $# -eq 0 ]]; then
         local filename="zipkin.jar"
         # shellcheck disable=SC2064
         trap "handle_shutdown \"$filename\" $*" EXIT
-    elif [ "$1" = '-h' ] || [ "$1" = '--help' ]; then
+    elif [[ "$1" = '-h' || "$1" = '--help' ]]; then
         usage
         exit
-    elif [ $# -eq 2 ]; then
+    elif [[ $# -eq 2 ]]; then
         local filename="$2"
         # shellcheck disable=SC2064
         trap "handle_shutdown \"$filename\" $*" EXIT
@@ -247,7 +247,7 @@ main() {
         exit 1
     fi
 
-    if [ -n "$artifact_classifier" ]; then
+    if [[ -n "$artifact_classifier" ]]; then
         artifact_classifier_suffix="-$artifact_classifier"
     else
         artifact_classifier_suffix=''

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -24,10 +24,10 @@ Downloads the "VERSION" version of GROUP:ARTIFACT with classifier "CLASSIFIER"
 to path "TARGET" on the local file system. "VERSION" can take the special value
 "LATEST", in which case the latest Zipkin release will be used. For example:
 
-${color_title}$0 io.zipkin.aws:zipkin-autoconfigure-collector-kinesis:LATEST:module kinesis.jar${color_reset}
+${color_title}$0 io.zipkin.java:zipkin-autoconfigure-collector-scribe:LATEST:module scribe.jar${color_reset}
 downloads the latest version of the artifact with group "io.zipkin.aws",
-artifact id "zipkin-autoconfigure-collector-kinesis", and classifier "module"
-to PWD/kinesis.jar
+artifact id "zipkin-autoconfigure-collector-scribe", and classifier "module"
+to PWD/scribe.jar
 EOF
 }
 

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -161,13 +161,14 @@ verify_checksum() {
     local url="$1"; shift
     local filename="$1"; shift
 
+    echo
+    echo "${color_title}Verifying checksum...${color_reset}"
+
     # Fetch the .md5 file even if md5sum is not on the path
     # This lets us verify its GPG signature later on, and the user might have another way of checksum verification
     fetch "$url.md5" "$filename.md5"
 
     if command -v md5sum >/dev/null 2>&1; then
-        echo
-        echo "${color_title}Verifying checksum...${color_reset}"
         execute_and_log "echo \"\$(cat $filename.md5)  $filename\" | md5sum --check"
         echo "${color_good}Checksum for ${filename} passes verification${color_reset}"
     else
@@ -179,11 +180,12 @@ verify_signature() {
     local url="$1"; shift
     local filename="$1"; shift
 
+    echo
+    echo "${color_title}Verifying GPG signature of $filename...${color_reset}"
+
     local bintray_gpg_key='D401AB61'
 
     if command -v gpg >/dev/null 2>&1; then
-        echo
-        echo "${color_title}Verifying GPG signature of $filename...${color_reset}"
         fetch "$url.asc" "$filename.asc"
         if gpg --list-keys "$bintray_gpg_key" >/dev/null 2>&1; then
             execute_and_log gpg --verify "$filename.asc" "$filename"

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -61,13 +61,21 @@ EOF
     echo -n "$color_reset"
 }
 
+cleanup() {
+    local base_filename="$1"; shift
+    if [ "$DO_CLEANUP" -eq 0 ]; then
+        echo
+        echo "${color_title}Cleaning up checksum and signature files${color_reset}"
+        execute_and_log rm -f "$base_filename"{.md5,.asc,.md5.asc}
+        DO_CLEANUP=1
+    fi
+}
+
 handle_shutdown() {
     local status=$?
     local base_filename="$1"; shift
     if [ $status -eq 0 ]; then
-        if [ "$DO_CLEANUP" -eq 0 ]; then
-            rm -f "$base_filename"{.md5,.asc,.md5.asc}
-        fi
+        cleanup "$base_filename"
     else
         cat <<EOF
 ${color_bad}
@@ -264,6 +272,7 @@ main() {
     verify_signature "$artifact_url" "$filename"
     verify_signature "$artifact_url.md5" "$filename.md5"
 
+    cleanup "$filename"
     farewell "$artifact_classifier" "$filename"
 }
 


### PR DESCRIPTION
Best part of being on vacation is I get to not feel guilty for tricking out shell scripts.

This PR makes the output of `quickstart.sh` more human-friendly, I think, by adding colors and slightly more words. Also, it fixes warnings issued by shellcheck.

Since this is a UI change (HAH!), below are some screenshots. First, one from a “perfect” run:

![2018-08-31-133538_1819x1226](https://user-images.githubusercontent.com/59982/44910272-dba02900-ad22-11e8-948e-bb40257e8588.png)

Here's one with a few warnings:

![2018-08-31-134503_1823x1231](https://user-images.githubusercontent.com/59982/44910594-122a7380-ad24-11e8-8913-402d16b9335d.png)

And here's one that fails due to PEBKAC:

![2018-08-31-133820_1727x654](https://user-images.githubusercontent.com/59982/44910346-228e1e80-ad23-11e8-9a8c-3f829afcb369.png)
