### PR TITLE
Make quickstart.sh compatible with Bash 3

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -263,7 +263,7 @@ main() {
 
     welcome
 
-    artifact_version_lowercase="${artifact_version,,}"
+    artifact_version_lowercase="$(tr '[:upper:]' '[:lower:]' <<< "$artifact_version")"
     if [  "${artifact_version_lowercase}" = 'latest' ]; then
         printf '%s\n' "${color_title}Fetching version number of latest ${artifact_group}:${artifact_id} release...${color_reset}"
         artifact_version="$(fetch_latest_version "$artifact_group" "$artifact_id")"


### PR DESCRIPTION
A recent change (49e6083938c8f051c2b7500bdd265634f4fa86c8) moved to a Bash 4 only syntax, which caused the quickstart script to fail on Bash 3. This commit restores Bash 3 compatibility while hopefully still addressing the concern in the original commit.

SO reference: https://stackoverflow.com/questions/2264428/how-to-convert-a-string-to-lower-case-in-bash#comment56199987_18363058

Gitter report: https://gitter.im/openzipkin/zipkin-dev?at=5b99ed91f4bd1056ac56069e

Review requested from @abesto 