### PR TITLE
Warns and redirects to the new group ID

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -224,6 +224,11 @@ main() {
 
     welcome
 
+    if [ "${artifact_group}" = 'io.zipkin.java' ]; then
+       printf '%s\n' "${color_warn}You've requested the server's old group name: 'io.zipkin.java'. Please update links to the current group 'io.zipkin'...${color_reset}"
+       artifact_group=io.zipkin
+    fi
+
     artifact_group_with_slashes="${artifact_group//.//}"
     artifact_version_lowercase="$(tr '[:upper:]' '[:lower:]' <<< "$artifact_version")"
     if [  "${artifact_version_lowercase}" = 'latest' ]; then


### PR DESCRIPTION
It is unlikely someone will manually enter zipkin's old group ID, but
just in case.


<img width="851" alt="Screenshot 2019-08-12 at 8 10 10 AM" src="https://user-images.githubusercontent.com/64215/62841279-cffe0600-bcd8-11e9-8c73-9ca8c78552ad.png">

Fixes #139