### PR TITLE
Update docs for Jaeger backend

### DIFF
--- a/pages/extensions_choices.md
+++ b/pages/extensions_choices.md
@@ -43,7 +43,7 @@ Listed below are alternative backends that accept Zipkin format. Some use the sa
      - this extension uses the same encoding library and same endpoints as Zipkin does.
  - [Jaeger](https://github.com/jaegertracing/jaeger)
    - When `COLLECTOR_ZIPKIN_HTTP_PORT=9411` is set, Jaeger exposes a partial implementation of Zipkin's HTTP POST endpoints
-     - http port 9411 accepts `/api/v1/spans` (thrift, json) and `/api/v2/spans` (json, but not proto) POST requests.
+     - http port 9411 accepts `/api/v1/spans` (thrift, json) and `/api/v2/spans` (json, proto) POST requests.
    - When `SPAN_STORAGE_TYPE=kafka` and `zipkin-thrift`, Jaeger reads Zipkin v1 thrift encoded span messages from a Kafka topic.
      - Note: The above is a [deprecated practice](https://github.com/openzipkin/zipkin/tree/master/zipkin-collector/kafka#legacy-encoding) in Zipkin. Most instrumentation bundle multiple spans per message in v2 format.
  - [Pitchfork](https://github.com/HotelsDotCom/pitchfork)


### PR DESCRIPTION
Signed-off-by: Abhilash Gnan <abhilashgnan@gmail.com>

Recent Jaeger v1.14 release added support for Zipkin proto support on `/api/v2/spans`

Refer to:
https://github.com/jaegertracing/jaeger/releases/tag/v1.14.0
https://github.com/jaegertracing/jaeger/pull/1695