### PR TITLE
Add a community supported tracer zipkin-clj (Clojure)

### DIFF
--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -25,6 +25,12 @@
   sampling: "Yes"
   notes: lc support. 4.5.2 or higher
 
+- language: "Clojure"
+  library: >-
+    [zipkin-clj](https://github.com/suprematic/zipkin-clj)
+  framework: Any
+  propagation: B3
+
 - language: Elixir
   library: >-
     [Tapper](https://github.com/Financial-Times/tapper)


### PR DESCRIPTION
Hi,
Here is a Clojure library for tracing. It's Zipkin oriented but theoretically can be used with other tracing systems. Please tell me if there are any special requirements for a library to get into the list of supported tracers.