### PR TITLE
Add action to check expiry of zipkin.io

### DIFF
--- a/.github/workflows/check-domain-expiry.yml
+++ b/.github/workflows/check-domain-expiry.yml
@@ -1,3 +1,8 @@
+# GitHub Pages publishes this site as "zipkin.io" according to the `CNAME` file.
+# Currently, the core team does not have access to the GoDaddy account for "zipkin.io".
+#
+# This workflow raises an issue when "zipkin.io" is about to expire, allowing watchers,
+# most specifically the core team, to follow-up and avoid site outages.
 name: Check domain expiry
 on:
   schedule:

--- a/.github/workflows/check-domain-expiry.yml
+++ b/.github/workflows/check-domain-expiry.yml
@@ -1,0 +1,20 @@
+name: Check domain expiry
+on:
+  schedule:
+    - cron: '12 22 * * *'
+
+jobs:
+  build:
+    name: Check zipkin.io expiration
+    # MacOS comes with whois installed by default
+    runs-on: macos-latest
+    steps:
+      # Exit code 0 if more than 30 days until expiration, 1 otherwise
+      - run:  exit $((($(date -j -f %Y-%m-%dT%H:%M:%SZ "$(whois zipkin.io | awk '/Registry Expiry Date:/ { print $4 }')" +%s) - $(date +%s)) / 3600 / 24 > 30 == 0))
+      - uses: maxkomarychev/oction-create-issue@v0.7.1
+        if: failure()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: zipkin.io domain about to expire
+          body: zipkin.io is going to expire in less than 30 days. Renew ASAP!
+          labels: bug


### PR DESCRIPTION
Adds daily check of zipkin.io expiry and files an issue if less than 30 days left.