### PR TITLE
adding echo zipkin tracing to community tracers instrumentations

### DIFF
--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -71,6 +71,15 @@
   transports: Scribe, UDP, easy to add others
   sampling: "Yes"
 
+- language: Go
+  library: >-
+    [zipkintracing](https://github.com/labstack/echo-contrib/tree/master/zipkintracing)
+  framework: >-
+    [Echo](https://echo.labstack.com/)
+  propagation: Http (B3), easy to add others
+  transports: Http
+  sampling: "Yes"  
+
 - language: Java
   library: >-
     [cassandra-zipkin-tracing](https://github.com/thelastpickle/cassandra-zipkin-tracing)


### PR DESCRIPTION
Adding https://github.com/labstack/echo-contrib/tree/master/zipkintracing to community tracers instrumentations. 

cc: @jcchavezs 