### PR TITLE
doc(pages.quickstart): replace docker zipkin url

### DIFF
--- a/pages/quickstart.md
+++ b/pages/quickstart.md
@@ -14,7 +14,7 @@ Regardless of how you start Zipkin, browse to http://your_host:9411 to find trac
 
 ## Docker
 
-The [Docker Zipkin](https://github.com/openzipkin/zipkin/tree/master/docker) project is able to build docker images, provide scripts and a [`docker-compose.yml`](https://github.com/openzipkin/docker-zipkin/blob/master/docker-compose.yml)
+The [Docker Zipkin](https://github.com/openzipkin/zipkin/tree/master/docker) project is able to build docker images, provide scripts and a [`docker-compose.yml`](https://github.com/openzipkin/zipkin/blob/master/docker/examples/docker-compose.yml)
 for launching pre-built images. The quickest start is to run the latest image directly:
 
 ~~~ bash

--- a/pages/quickstart.md
+++ b/pages/quickstart.md
@@ -14,7 +14,7 @@ Regardless of how you start Zipkin, browse to http://your_host:9411 to find trac
 
 ## Docker
 
-The [Docker Zipkin](https://github.com/openzipkin/docker-zipkin) project is able to build docker images, provide scripts and a [`docker-compose.yml`](https://github.com/openzipkin/docker-zipkin/blob/master/docker-compose.yml)
+The [Docker Zipkin](https://github.com/openzipkin/zipkin/tree/master/docker) project is able to build docker images, provide scripts and a [`docker-compose.yml`](https://github.com/openzipkin/docker-zipkin/blob/master/docker-compose.yml)
 for launching pre-built images. The quickest start is to run the latest image directly:
 
 ~~~ bash


### PR DESCRIPTION
## Description
* Replace Docker Zipkin url, 👁️ pointing to [archived repo](https://github.com/openzipkin-attic/docker-zipkin) 👁️ , by the new [repo](https://github.com/openzipkin/zipkin/tree/master/docker)

## How to review?
* Check the URLs are valid