### PR TITLE
doc(data): add micrometer as communitry tracer

### DIFF
--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -39,7 +39,7 @@
 - language: Java
   library: >-
     [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
-  framework: Spring, Quarkus, Micronaut, Helidon
+  framework: Spring Framework 6+, Quarkus, Micronaut, Helidon
   propagation: B3, W3C
   transports: Http
   sampling: "Yes"

--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -39,7 +39,7 @@
 - language: Java
   library: >-
     [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
-  framework: Spring Framework 6+, Quarkus, Micronaut, Helidon
+  framework: Spring Boot 3+
   propagation: B3, W3C
   transports: Http
   sampling: "Yes"

--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -30,6 +30,7 @@
 - language: Java
   library: >-
     [Spring Cloud Sleuth](https://github.com/spring-cloud/spring-cloud-sleuth)
+    [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
   framework: Spring, Spring Cloud (e.g. Stream, Netflix)
   propagation: Http (B3), Messaging (B3)
   transports: Http, Spring Cloud Stream Compatible (e.g. RabbitMQ, Kafka, Redis or anything with a custom Binder)

--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -40,7 +40,7 @@
   library: >-
     [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
   framework: Spring, Quarkus, Micronaut, Helidon
-  propagation: Http (B3), Messaging (B3), W3C(B3)
+  propagation: B3, W3C
   transports: Http
   sampling: "Yes"
   notes: Java 8+

--- a/_data/community_tracers_instrumentation.yml
+++ b/_data/community_tracers_instrumentation.yml
@@ -30,12 +30,20 @@
 - language: Java
   library: >-
     [Spring Cloud Sleuth](https://github.com/spring-cloud/spring-cloud-sleuth)
-    [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
   framework: Spring, Spring Cloud (e.g. Stream, Netflix)
   propagation: Http (B3), Messaging (B3)
   transports: Http, Spring Cloud Stream Compatible (e.g. RabbitMQ, Kafka, Redis or anything with a custom Binder)
   sampling: "Yes"
   notes: Java 7 or higher
+
+- language: Java
+  library: >-
+    [Micrometer Tracing](https://github.com/micrometer-metrics/tracing)
+  framework: Spring, Quarkus, Micronaut, Helidon
+  propagation: Http (B3), Messaging (B3), W3C(B3)
+  transports: Http
+  sampling: "Yes"
+  notes: Java 8+
 
 - language: Java
   library: >-


### PR DESCRIPTION
## Description
* add micrometer as community tracer
  * [micrometer tracing](https://github.com/micrometer-metrics/tracing) is the successor to the [Spring Cloud Sleuth project](https://micrometer.io/)

## How to review?
* Check the URLs are valid
* Confirm the veracity of my words inthe documentation referred up