### PR TITLE
List on Artifacthub: add initial artifacthub-repo.yml to claim repository ownership

### DIFF
--- a/zipkin-helm/artifacthub-repo.yml
+++ b/zipkin-helm/artifacthub-repo.yml
@@ -1,0 +1,5 @@
+owners:
+  - name: reta
+    email: drreta@gmail.com
+  - name: openzipkin
+    email: zipkin-dev@googlegroups.com

--- a/zipkin-helm/index.html
+++ b/zipkin-helm/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Redirecting to https://github.com/openzipkin/zipkin-helm ...</title>
+    <meta http-equiv="refresh" content="0; https://github.com/openzipkin/zipkin-helm" />
+  </head>
+  <body>
+    <p>Redirecting to https://github.com/openzipkin/zipkin-helm ...</p>
+  </body>
+</html>


### PR DESCRIPTION
The Artifacthub package https://artifacthub.io/packages/helm/zipkin/zipkin refers to `https://zipkin.io/zipkin-helm` repository, adding the `artifacthub-repo.yml` over there so it could be discovered by Artifacthub (verified locally, `http://localhost:4000/zipkin-helm/artifacthub-repo.yml` is fully accessible)