### PR TITLE
Revert "List on Artifacthub: add initial artifacthub-repo.yml to claim repository ownership"

### DIFF
--- a/zipkin-helm/artifacthub-repo.yml
+++ b/zipkin-helm/artifacthub-repo.yml
@@ -1,5 +1,0 @@
-owners:
-  - name: reta
-    email: drreta@gmail.com
-  - name: openzipkin
-    email: zipkin-dev@googlegroups.com

--- a/zipkin-helm/index.html
+++ b/zipkin-helm/index.html
@@ -1,9 +1,0 @@
-<html>
-  <head>
-    <title>Redirecting to https://github.com/openzipkin/zipkin-helm ...</title>
-    <meta http-equiv="refresh" content="0; https://github.com/openzipkin/zipkin-helm" />
-  </head>
-  <body>
-    <p>Redirecting to https://github.com/openzipkin/zipkin-helm ...</p>
-  </body>
-</html>


### PR DESCRIPTION
Reverts openzipkin/openzipkin.github.io#182, the change should go to `gh-pages` branch of the `zipkin-help` repo